### PR TITLE
use --locked with cargo install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ The tower can be installed and tested using cargo:
 ```
 git clone https://github.com/talaia-labs/rust-teos.git
 cd rust-teos
-cargo install --path teos
+cargo install --locked --path teos
 ```
 
 You can run tests with:

--- a/watchtower-plugin/README.md
+++ b/watchtower-plugin/README.md
@@ -25,7 +25,7 @@ The plugin also has an implicit method to send appointments to the registered to
 The first step to add the plugin to CLN is installing it. To do so you need to run (from the `rust-teos` folder):
 
 ```
-cargo install --path watchtower-plugin
+cargo install --locked --path watchtower-plugin
 ```
 
 That will generate a binary called `watchtower-client`. That's the binary we need to link to CLN.


### PR DESCRIPTION
Using --locked with cargo install(s) willinstruct cargo to use the lock file in the repo Cargo.lock.
So all the users builds will be identical to builds in the master branch.

Quicke from github codespaces :)